### PR TITLE
Fix Dream cleanup after context reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-This changelog starts with the Metis `rc-1.0.0` release candidate. Earlier development history is available through Git.
+This changelog starts with the Metis `1.0.0-rc.1` release candidate. Earlier development history is available through Git.
 
-## [rc-1.0.0] - 2026-07-12
+## [1.0.0-rc.1] - 2026-07-12
 
 ### Highlights
 
@@ -40,4 +40,4 @@ This changelog starts with the Metis `rc-1.0.0` release candidate. Earlier devel
 
 ### Release candidate notice
 
-`rc-1.0.0` is a release candidate. Public APIs, Extension events, Package metadata, and behavior may still change before the stable `1.0.0` release.
+`1.0.0-rc.1` is a release candidate. Public APIs, Extension events, Package metadata, and behavior may still change before the stable `1.0.0` release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This changelog starts with the Metis `1.0.0-rc.1` release candidate. Earlier development history is available through Git.
 
+## [1.0.0-rc.2] - 2026-07-13
+
+### Fixes
+
+- Kept Dream Phase cleanup and state updates working after the originating Extension context becomes stale.
+- Avoided stale-context UI notifications after session replacement or Extension reload.
+
+### Documentation
+
+- Updated English and Simplified Chinese Quick Start instructions to install Metis directly from npm.
+
 ## [1.0.0-rc.1] - 2026-07-12
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -23,17 +23,14 @@
 Requires Node.js `>=22.19.0` and npm.
 
 ```bash
-git clone https://github.com/Wholiver/metis.git
-cd metis
-npm install
-npm run build
-node dist/cli.js
+npm install -g @wholiver_hu/metis@rc
+metis
 ```
 
 To see available options:
 
 ```bash
-node dist/cli.js --help
+metis --help
 ```
 
 ## Why Metis

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,17 +23,14 @@
 需要 Node.js `>=22.19.0` 和 npm。
 
 ```bash
-git clone https://github.com/Wholiver/metis.git
-cd metis
-npm install
-npm run build
-node dist/cli.js
+npm install -g @wholiver_hu/metis@rc
+metis
 ```
 
 查看可用的命令行选项：
 
 ```bash
-node dist/cli.js --help
+metis --help
 ```
 
 ## 为什么选择 Metis

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
 	"name": "@wholiver_hu/metis",
-	"version": "0.80.18",
+	"version": "1.0.0-rc.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@wholiver_hu/metis",
-			"version": "0.80.18",
+			"version": "1.0.0-rc.1",
 			"bundleDependencies": [
 				"@earendil-works/metis-agent-core",
 				"@earendil-works/metis-ai",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
 	"name": "@wholiver_hu/metis",
-	"version": "1.0.0-rc.1",
+	"version": "1.0.0-rc.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@wholiver_hu/metis",
-			"version": "1.0.0-rc.1",
+			"version": "1.0.0-rc.2",
 			"bundleDependencies": [
 				"@earendil-works/metis-agent-core",
 				"@earendil-works/metis-ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wholiver_hu/metis",
-	"version": "0.80.18",
-	"description": "Metis coding agent CLI with read, bash, edit, write tools and session management",
+	"version": "1.0.0-rc.1",
+	"description": "A terminal-first coding agent that helps models search, remember, execute, and verify more reliably",
 	"type": "module",
 	"metisConfig": {
 		"name": "metis",
@@ -27,17 +27,21 @@
 		"examples",
 		"containerization.md",
 		"CHANGELOG.md",
+		"CONTRIBUTING.md",
+		"CONTRIBUTING.zh-CN.md",
+		"AGENTS.md",
+		"README.zh-CN.md",
 		"npm-shrinkwrap.json"
 	],
 	"scripts": {
-		"clean": "shx rm -rf dist",
-		"build": "npm run clean && tsgo -p tsconfig.build.json && shx chmod +x dist/cli.js dist/rpc-entry.js && npm run copy-assets",
+		"clean": "node scripts/clean.mjs",
+		"build": "npm run clean && tsgo -p tsconfig.build.json && node scripts/copy-assets.mjs",
 		"build:binary": "npm --prefix ../tui run build && npm --prefix ../ai run build && npm --prefix ../agent run build && npm run build && bun build --compile ./dist/bun/cli.js ./src/utils/image-resize-worker.ts --outfile dist/metis && npm run copy-binary-assets",
-		"copy-assets": "shx mkdir -p dist/modes/interactive/theme && shx cp src/modes/interactive/theme/*.json dist/modes/interactive/theme/ && shx mkdir -p dist/modes/interactive/assets && shx cp src/modes/interactive/assets/*.png dist/modes/interactive/assets/ && shx mkdir -p dist/core/export-html/vendor && shx cp src/core/export-html/template.html src/core/export-html/template.css src/core/export-html/template.js dist/core/export-html/ && shx cp src/core/export-html/vendor/*.js dist/core/export-html/vendor/",
+		"copy-assets": "node scripts/copy-assets.mjs",
 		"copy-binary-assets": "shx cp package.json dist/ && shx cp README.md dist/ && shx cp CHANGELOG.md dist/ && shx mkdir -p dist/theme && shx cp src/modes/interactive/theme/*.json dist/theme/ && shx mkdir -p dist/assets && shx cp src/modes/interactive/assets/*.png dist/assets/ && shx mkdir -p dist/export-html/vendor && shx cp src/core/export-html/template.html dist/export-html/ && shx cp src/core/export-html/vendor/*.js dist/export-html/vendor/ && shx cp -r docs dist/ && shx cp -r examples dist/ && shx cp ../../node_modules/@silvia-odwyer/photon-node/photon_rs_bg.wasm dist/",
 		"test": "vitest --run",
 		"shrinkwrap": "node ../../scripts/generate-coding-agent-shrinkwrap.mjs",
-		"prepublishOnly": "npm run clean && npm run build"
+		"prepublishOnly": "npm run build"
 	},
 	"dependencies": {
 		"@earendil-works/metis-agent-core": "file:vendor/metis-agent-core",
@@ -97,11 +101,19 @@
 		"tui",
 		"agent"
 	],
-	"author": "Mario Zechner",
+	"author": "Wholiver",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/earendil-works/metis.git"
+		"url": "git+https://github.com/Wholiver/metis.git"
+	},
+	"homepage": "https://github.com/Wholiver/metis#readme",
+	"bugs": {
+		"url": "https://github.com/Wholiver/metis/issues"
+	},
+	"publishConfig": {
+		"access": "public",
+		"tag": "rc"
 	},
 	"engines": {
 		"node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wholiver_hu/metis",
-	"version": "1.0.0-rc.1",
+	"version": "1.0.0-rc.2",
 	"description": "A terminal-first coding agent that helps models search, remember, execute, and verify more reliably",
 	"type": "module",
 	"metisConfig": {

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,0 +1,3 @@
+import { rmSync } from "node:fs";
+
+rmSync(new URL("../dist", import.meta.url), { force: true, recursive: true });

--- a/scripts/copy-assets.mjs
+++ b/scripts/copy-assets.mjs
@@ -1,0 +1,39 @@
+import { chmodSync, cpSync, mkdirSync, readdirSync } from "node:fs";
+import { extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+function copyMatching(source, target, extensions) {
+	mkdirSync(target, { recursive: true });
+	for (const entry of readdirSync(source, { withFileTypes: true })) {
+		if (entry.isFile() && extensions.has(extname(entry.name))) {
+			cpSync(join(source, entry.name), join(target, entry.name));
+		}
+	}
+}
+
+copyMatching(
+	join(root, "src/modes/interactive/theme"),
+	join(root, "dist/modes/interactive/theme"),
+	new Set([".json"]),
+);
+copyMatching(
+	join(root, "src/modes/interactive/assets"),
+	join(root, "dist/modes/interactive/assets"),
+	new Set([".png", ".svg"]),
+);
+copyMatching(
+	join(root, "src/core/export-html"),
+	join(root, "dist/core/export-html"),
+	new Set([".html", ".css", ".js"]),
+);
+copyMatching(
+	join(root, "src/core/export-html/vendor"),
+	join(root, "dist/core/export-html/vendor"),
+	new Set([".js"]),
+);
+
+for (const executable of ["cli.js", "rpc-entry.js"]) {
+	chmodSync(join(root, "dist", executable), 0o755);
+}

--- a/src/core/builtins/dream-mode.ts
+++ b/src/core/builtins/dream-mode.ts
@@ -194,8 +194,8 @@ function resolveCurrentModel(ctx: ExtensionContext): { provider: string; id: str
 	return undefined;
 }
 
-function pruneTempLogs(ctx: ExtensionContext): void {
-	const tempDir = resolve(ctx.cwd, ".temp");
+function pruneTempLogs(cwd: string): void {
+	const tempDir = resolve(cwd, ".temp");
 	if (!existsSync(tempDir)) return;
 
 	const today = getTodayString();
@@ -258,7 +258,7 @@ function stopDreamCleanupWatcher(): void {
 	}
 }
 
-function startDreamCleanupWatcher(ctx: ExtensionContext, expectedDate: string): void {
+function startDreamCleanupWatcher(cwd: string, expectedDate: string): void {
 	stopDreamCleanupWatcher();
 	const startedAt = Date.now();
 
@@ -270,9 +270,8 @@ function startDreamCleanupWatcher(ctx: ExtensionContext, expectedDate: string): 
 		}
 
 		if (state.lastDreamDate === expectedDate) {
-			pruneTempLogs(ctx);
+			pruneTempLogs(cwd);
 			stopDreamCleanupWatcher();
-			updateStatusUI(ctx);
 			return;
 		}
 
@@ -282,7 +281,7 @@ function startDreamCleanupWatcher(ctx: ExtensionContext, expectedDate: string): 
 	}, 5 * 1000);
 }
 
-function spawnDreamCleanupHelper(ctx: ExtensionContext, expectedDate: string): void {
+function spawnDreamCleanupHelper(cwd: string, workingLogPath: string, expectedDate: string): void {
 	const dreamStatePath = getDreamStatePath();
 	const cleanupScript = `
 const { existsSync, readdirSync, rmSync, readFileSync, statSync } = require("fs");
@@ -348,10 +347,10 @@ const timer = setInterval(() => {
 		env: {
 			...process.env,
 			[DREAM_CLEANUP_HELPER_ENV]: "1",
-			METIS_DREAM_CLEANUP_TEMP_DIR: resolve(ctx.cwd, ".temp"),
+			METIS_DREAM_CLEANUP_TEMP_DIR: resolve(cwd, ".temp"),
 			METIS_DREAM_CLEANUP_STATE_PATH: dreamStatePath,
 			METIS_DREAM_CLEANUP_EXPECTED_DATE: expectedDate,
-			METIS_DREAM_CLEANUP_WORKING_LOG_PATH: getWorkingLogPath(ctx),
+			METIS_DREAM_CLEANUP_WORKING_LOG_PATH: workingLogPath,
 		},
 		stdio: "ignore",
 		detached: true,
@@ -380,11 +379,33 @@ function updateStatusUI(ctx: ExtensionContext) {
 	}
 }
 
+function isStaleExtensionContextError(error: unknown): boolean {
+	return error instanceof Error && error.message.startsWith("This extension ctx is stale after session replacement or reload.");
+}
+
+function notifyIfContextActive(ctx: ExtensionContext, message: string): void {
+	try {
+		ctx.ui.notify(message);
+	} catch (error) {
+		if (!isStaleExtensionContextError(error)) throw error;
+	}
+}
+
+function updateStatusUIIfContextActive(ctx: ExtensionContext): void {
+	try {
+		updateStatusUI(ctx);
+	} catch (error) {
+		if (!isStaleExtensionContextError(error)) throw error;
+	}
+}
+
 async function triggerDreamPhase(ctx: ExtensionContext, manual = false) {
 	if (isDreaming) return;
 
 	const state = readState();
 	if (!state.enabled) return;
+	const cwd = ctx.cwd;
+	const workingLogPath = getWorkingLogPath(ctx);
 
 	const today = getTodayString();
 	if (!manual && !shouldTriggerDream(state, today)) return;
@@ -406,8 +427,8 @@ async function triggerDreamPhase(ctx: ExtensionContext, manual = false) {
 
 	isDreaming = true;
 	updateStatusUI(ctx);
-	startDreamCleanupWatcher(ctx, today);
-	spawnDreamCleanupHelper(ctx, today);
+	startDreamCleanupWatcher(cwd, today);
+	spawnDreamCleanupHelper(cwd, workingLogPath, today);
 
 	try {
 		const childArgs = [
@@ -431,7 +452,7 @@ async function triggerDreamPhase(ctx: ExtensionContext, manual = false) {
 		child.on("exit", (code) => {
 			isDreaming = false;
 			if (code === 0) {
-				pruneTempLogs(ctx);
+				pruneTempLogs(cwd);
 				stopDreamCleanupWatcher();
 
 				const currentState = readState();
@@ -439,13 +460,14 @@ async function triggerDreamPhase(ctx: ExtensionContext, manual = false) {
 				delete currentState.nextDreamRetryAt;
 				delete currentState.lastDreamError;
 				writeState(currentState);
-				ctx.ui.notify("Background Dream Phase completed successfully.");
+				notifyIfContextActive(ctx, "Background Dream Phase completed successfully.");
 			} else {
 				stopDreamCleanupWatcher();
 				const currentState = readState();
 				const retryDelay = recordDreamFailure(currentState, `Exit code ${code ?? "unknown"}`);
 				writeState(currentState);
-				ctx.ui.notify(
+				notifyIfContextActive(
+					ctx,
 					`Background Dream Phase failed (exit code ${code}, likely LLM rate limit or API error). ${
 						retryDelay === undefined
 							? "Daily retry limit reached."
@@ -454,7 +476,7 @@ async function triggerDreamPhase(ctx: ExtensionContext, manual = false) {
 				);
 			}
 			releaseDreamLock(lockToken);
-			updateStatusUI(ctx);
+			updateStatusUIIfContextActive(ctx);
 		});
 
 		child.on("error", (err) => {
@@ -464,14 +486,15 @@ async function triggerDreamPhase(ctx: ExtensionContext, manual = false) {
 			const retryDelay = recordDreamFailure(currentState, err.message);
 			writeState(currentState);
 			releaseDreamLock(lockToken);
-			ctx.ui.notify(
+			notifyIfContextActive(
+				ctx,
 				`Failed to spawn Dream Phase: ${err.message}. ${
 					retryDelay === undefined
 						? "Daily retry limit reached."
 						: `Retrying automatically in ${formatRetryDelay(retryDelay)}.`
 				}`,
 			);
-			updateStatusUI(ctx);
+			updateStatusUIIfContextActive(ctx);
 		});
 
 		child.unref();

--- a/test/suite/regressions/dream-builtin.test.ts
+++ b/test/suite/regressions/dream-builtin.test.ts
@@ -197,6 +197,62 @@ describe("dream builtin registration", () => {
 		);
 	});
 
+	it("finishes child cleanup after its extension context becomes stale", async () => {
+		tempRoot = mkdtempSync(join(tmpdir(), "metis-dream-stale-context-"));
+		const cwd = join(tempRoot, "project");
+		const agentDir = join(tempRoot, "agent");
+		mkdirSync(join(cwd, ".temp"), { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+		process.env.METIS_CODING_AGENT_DIR = agentDir;
+		writeFileSync(join(tempRoot, "dream_state.json"), JSON.stringify({ enabled: true, lastDreamDate: "2000-01-01" }));
+
+		const handlers = new Map<string, Array<(event: unknown, ctx: any) => void>>();
+		dreamMode({
+			registerCommand: vi.fn(),
+			on(event: string, handler: (event: unknown, ctx: any) => void) {
+				handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+			},
+		} as any);
+		const spawned: EventEmitter[] = [];
+		spawnMock.mockImplementation(() => {
+			const child = new EventEmitter() as EventEmitter & { unref: () => void };
+			child.unref = vi.fn();
+			spawned.push(child);
+			return child;
+		});
+		vi.spyOn(globalThis, "setInterval").mockReturnValue(1 as any);
+		vi.spyOn(globalThis, "clearInterval").mockImplementation(() => undefined);
+
+		let active = true;
+		const staleError = () => new Error("This extension ctx is stale after session replacement or reload.");
+		const setStatus = vi.fn();
+		const notify = vi.fn();
+		const ctx = {
+			get cwd() {
+				if (!active) throw staleError();
+				return cwd;
+			},
+			hasPendingMessages: () => false,
+			isIdle: () => true,
+			sessionManager: { getBranch: () => [], getCwd: () => cwd, getSessionId: () => "test-session" },
+			get ui() {
+				if (!active) throw staleError();
+				return { setStatus, notify };
+			},
+		};
+
+		await handlers.get("session_start")?.[0]?.({}, ctx);
+		expect(spawned).toHaveLength(2);
+
+		active = false;
+		expect(() => spawned[1]?.emit("exit", 0)).not.toThrow();
+		expect(JSON.parse(readFileSync(join(tempRoot, "dream_state.json"), "utf-8"))).toMatchObject({
+			enabled: true,
+			lastDreamDate: expect.not.stringMatching(/^2000-01-01$/),
+		});
+		expect(notify).not.toHaveBeenCalled();
+	});
+
 	it("does not start a second dream while another process holds the lock", async () => {
 		tempRoot = mkdtempSync(join(tmpdir(), "metis-dream-lock-"));
 		const cwd = join(tempRoot, "project");


### PR DESCRIPTION
## What changed

- keep Dream child cleanup independent from stale extension context access
- suppress stale-context UI updates after session replacement or reload
- add regression coverage for successful cleanup after context invalidation
- switch English and Chinese Quick Start sections to npm installation
- prepare the `1.0.0-rc.2` npm release

## Why

Dream child processes can finish after their originating extension context has been replaced. Cleanup and state updates must still complete without touching stale context-backed UI or path getters.

## Validation

- `npm run build` passed and generated CLI/RPC artifacts
- `git diff --check` passed
- `npm test -- test/suite/regressions/dream-builtin.test.ts --reporter=dot` passed: 6 tests
- packed tarball installed in isolation and `metis --version` returned `1.0.0-rc.2`
