### PR TITLE
fix(desktop): avoid restoring unknown custom models

### DIFF
--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -1,6 +1,7 @@
 const desktop = window.metisDesktop;
 const desktopI18n = window.metisDesktopI18n;
 const { analyzeAssistantTurn, shouldQueueDesktopMessage, getAssistantWorkLayout, getSubagentToolCalls, shouldHideAssistantWorkHeader, getAssistantTurnDuration, reconcileAssistantFinalDivider, isSubagentLaunchNotice } = window.metisMessageTurns;
+const { resolveCustomProviderModel } = window.metisModelSelection;
 const THINKING_LEVEL_KEYS = {
 	off: "thinkingOff",
 	minimal: "thinkingMinimal",
@@ -3274,12 +3275,9 @@ document.querySelector("#settingsCustomProviderSaveButton")?.addEventListener("c
 	await runVisualCommand("/reload", elements.settingsSecurityFeedback, { refresh: true });
 	await runVisualCommand(`/login other ${apiKey}`, elements.settingsSecurityFeedback, { refresh: true });
 	// Re-apply the active model so thinking capability updates without a manual switch.
-	const provider = previousModel?.provider || "other";
-	const modelId = previousModel?.id
-		|| state.models.find((model) => model.provider === provider)?.id
-		|| state.models.find((model) => model.provider === "other")?.id;
-	if (modelId) {
-		await requestServer("/session/model", "PUT", { provider, modelId });
+	const model = resolveCustomProviderModel(previousModel, state.models);
+	if (model) {
+		await requestServer("/session/model", "PUT", { provider: model.provider, modelId: model.id });
 	}
 	await syncServerSession({ loadModels: true });
 	await loadVisualSettings();

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -614,6 +614,7 @@
 	<script src="i18n.js"></script>
 	<script src="conversations.js"></script>
 	<script src="message-turns.js"></script>
+	<script src="model-selection.js"></script>
 	<script src="onboarding.js"></script>
 	<script src="app.js"></script>
 </body>

--- a/desktop/renderer/model-selection.js
+++ b/desktop/renderer/model-selection.js
@@ -1,0 +1,16 @@
+(function initModelSelection(globalScope) {
+	function resolveCustomProviderModel(previousModel, models) {
+		const availableModels = Array.isArray(models) ? models : [];
+		const previous = availableModels.find((model) => (
+			model.provider === previousModel?.provider && model.id === previousModel?.id
+		));
+		if (previous) return { provider: previous.provider, id: previous.id };
+
+		const custom = availableModels.find((model) => model.provider === "other");
+		return custom ? { provider: custom.provider, id: custom.id } : undefined;
+	}
+
+	const helpers = Object.freeze({ resolveCustomProviderModel });
+	if (typeof module === "object" && module.exports) module.exports = helpers;
+	globalScope.metisModelSelection = helpers;
+})(typeof window === "undefined" ? globalThis : window);

--- a/test/desktop-model-selection.test.ts
+++ b/test/desktop-model-selection.test.ts
@@ -1,0 +1,24 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { resolveCustomProviderModel } = require("../desktop/renderer/model-selection.js") as {
+	resolveCustomProviderModel: (
+		previousModel: { provider?: string; id?: string; api?: string } | undefined,
+		models: Array<{ provider: string; id: string }>,
+	) => { provider: string; id: string } | undefined;
+};
+
+describe("desktop model selection", () => {
+	it("selects the imported custom model when the current model is the unknown placeholder", () => {
+		const models = [
+			{ provider: "anthropic", id: "claude" },
+			{ provider: "other", id: "gpt-custom" },
+		];
+
+		expect(resolveCustomProviderModel(
+			{ provider: "unknown", id: "unknown", api: "unknown" },
+			models,
+		)).toEqual({ provider: "other", id: "gpt-custom" });
+	});
+});


### PR DESCRIPTION
## Summary

- Prevent Desktop from restoring the internal `unknown/unknown` placeholder.
- Preserve the previous model only when it still exists.
- Fall back to the newly imported custom `other` model.
- Add regression coverage for custom model selection.

## Test plan

- [x] Desktop model-selection tests pass
- [x] Desktop renderer builds successfully
- [x] Diff whitespace check passes