### PR TITLE
docs: refresh README content

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,79 +17,83 @@
 </p>
 
 <p align="center">
-  <strong>Help coding models write better code and finish faster with better context, reusable experience, and verified results.</strong>
+  <strong>A coding agent that searches, remembers, executes, and verifies across terminal and desktop.</strong>
 </p>
 
 <p align="center">
-  <a href="#why-metis">Why Metis</a> ·
-  <a href="#better-coding-performance">Coding performance</a> ·
-  <a href="#what-makes-it-reliable">Reliability</a> ·
-  <a href="#quick-start">Quick start</a>
+  <a href="#quick-start">Quick start</a> ·
+  <a href="#highlights">Highlights</a> ·
+  <a href="#how-metis-works">How it works</a> ·
+  <a href="#documentation">Documentation</a>
 </p>
 
 ---
 
 ## Quick start
 
-Choose one interface. Both use the same Metis configuration, models, and sessions.
+### CLI
 
-| Interface | Best for | Requirement |
-| --- | --- | --- |
-| **Desktop app** | Graphical workspace with CLI and server included | Apple silicon Mac (`arm64`) or Windows (`x64`) |
-| **CLI** | Terminal, scripts, print/JSON, RPC, and SDK integrations | Node.js `>=22.19.0` and `npm` |
-
-### Desktop app for macOS
-
-1. [Download the latest Apple silicon `.dmg`](https://github.com/Wholiver/metis/releases/latest) (`Metis-*-macos-arm64.dmg`).
-2. Open it and drag **Metis.app** into **Applications**.
-3. Launch **Metis**. Node.js is already included.
-
-### Desktop app for Windows
-
-The Windows build bundles the full Metis CLI and server runtime. Choose the setup EXE for a normal installation or the ZIP for a portable copy.
-
-> **Current build:** Windows `x64`. No separate Node.js installation is required.
-
-1. Open the [latest GitHub Release](https://github.com/Wholiver/metis/releases/latest).
-2. Download and run `Metis-*-win-x64-setup.exe`, or download `Metis-*-win-x64.zip`, extract it, and launch **Metis.exe** from the **Metis** folder.
-3. Use the attached `.sha256` file to verify your download. If Windows SmartScreen warns about an unknown publisher, continue only when the file came from the official release page.
-
-### CLI and terminal
-
-Install Metis, then start an interactive session:
+Requires Node.js `>=22.19.0` and npm.
 
 ```bash
 npm install -g --ignore-scripts @wholiver_hu/metis@latest
 metis
 ```
 
-Run `metis --help` to view every CLI option.
+Use `/login` for supported subscription providers, or configure an API key. Run `metis --help` for CLI options and see the [Quickstart](docs/quickstart.md) for the complete first-run flow.
 
-## Why Metis
+<details>
+<summary><strong>Desktop installation (macOS and Windows)</strong></summary>
 
-Metis is an agent layer for coding models. It does not replace the model or change its weights. It improves the model's effective coding performance by giving it a better way to search, remember, work, and check its own result.
+Desktop includes the Metis CLI and Server runtime; Node.js is not required separately.
 
-That means better repository understanding, fewer unsupported assumptions and missed requirements, stronger task completion, and less time spent repeating context.
+| Platform | Build | Install |
+| --- | --- | --- |
+| macOS | Apple silicon (`arm64`) | Download `Metis-*-macos-arm64.dmg`, then drag **Metis.app** to **Applications**. |
+| Windows | `x64` | Run `Metis-*-win-x64-setup.exe`, or extract `Metis-*-win-x64.zip` and launch **Metis.exe**. |
 
-### Better coding performance
+Download files and matching `.sha256` checksums from the [latest GitHub Release](https://github.com/Wholiver/metis/releases/latest). If Windows SmartScreen reports an unknown publisher, continue only when the file came from the official release page and its checksum matches.
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/images/metis-coding-performance.dark.png" />
-    <img src="docs/images/metis-coding-performance.png" width="100%" alt="How Metis helps the same coding model achieve better coding outcomes" />
-  </picture>
-</p>
+</details>
 
-For the same underlying model, Metis strengthens the system around it:
+## Highlights
 
-- **Relevant context** — search the repository and authoritative sources before editing.
-- **Reusable experience** — carry useful decisions, lessons, and technical knowledge into later work.
-- **Evidence-based implementation** — follow existing code, constraints, and project conventions instead of guessing.
-- **Verified completion** — build, test, inspect output, and compare the result with the original request.
+- **Plan and Build workflows** — investigate safely in read-only Plan mode, then execute an approved proposal with a persistent checklist in Build mode.
+- **Durable memory and recovery** — search reusable project knowledge and resume work after interruption, compaction, or session reload.
+- **Flexible models and authentication** — use built-in subscription login, API-key providers, or custom OpenAI-compatible providers with model discovery.
+- **Desktop workspace** — attach images, videos, text, and other files through the picker, clipboard, or drag and drop; manage providers and sessions graphically.
+- **Video evidence** — inspect local video through metadata, timestamped storyboards, ordered motion samples, high-resolution frames, subtitles, and local transcription.
+- **Extensible core** — add TypeScript extensions, Agent Skills, prompt templates, themes, and Metis packages; integrate through print, JSON, RPC, Server, or the Node.js SDK.
+- **Verified execution** — coordinate subagents, preserve tool-result ordering, run relevant checks, and compare delivery against the original request.
 
-These mechanisms can improve practical coding outcomes without retraining or replacing the model. Results still depend on the model, task, tools, and environment.
+## How Metis works
 
-### Faster completion
+1. **Ground** — load trusted instructions and relevant context, then search code, memory, or authoritative sources when needed.
+2. **Plan or build** — Plan mode stays read-only and produces a durable proposal; Build mode performs evidence-supported changes.
+3. **Persist** — retain sessions, message/tool pairs, workflow checkpoints, plans, and compacted context.
+4. **Verify** — run risk-proportionate checks and report completed requirements, evidence, and remaining risk.
+
+<details>
+<summary><strong>Technical design</strong></summary>
+
+### Deterministic workflow runtime
+
+Metis freezes a `StepSnapshot` before every model sample. Model, reasoning level, collaboration mode, instructions, messages, visible tools, dispatcher, and context window therefore remain consistent for that step. Safe reads may run in parallel; writes and mixed tools are serialized. Steering and follow-ups are applied only after current tool results persist.
+
+### Plans and interactive input
+
+New interactive and Desktop sessions start in Plan mode. `/mode plan` and `/mode build` switch workflows when idle. Approved proposals survive reload and compaction through `read_plan`; Build checklists update in place in TUI and Desktop. Interactive hosts can answer `ask_user`, while unattended print/JSON and SDK runs return a recoverable unsupported result instead of hanging.
+
+### Memory
+
+Metis checkpoints active work after prompts, completed steps, compaction, errors, aborts, and completion. Durable records and their search index live in `~/.metis/memories/state.sqlite`, with inspectable global and project `MEMORY.md` views. `search_memory` is available on demand in Plan and Build; results are advisory and never override current instructions.
+
+Use `/memory status|on|off|run|search|forget|reset`. Proposal artifacts and long-term memory remain separate, so an unexecuted draft is not promoted automatically.
+
+</details>
+
+<details>
+<summary><strong>Performance example</strong></summary>
 
 <p align="center">
   <picture>
@@ -98,98 +102,42 @@ These mechanisms can improve practical coding outcomes without retraining or rep
   </picture>
 </p>
 
-In one user test with the same task:
+In one user test on the same task, Metis finished in 1 minute 30 seconds and OpenCode in 3 minutes 30 seconds, with no observed accuracy difference. This single comparison is not a universal benchmark; results depend on the task, model, tools, and environment.
 
-- **Metis finished in 1 minute 30 seconds.**
-- **OpenCode finished in 3 minutes 30 seconds.**
-- No accuracy difference was observed in that test.
+</details>
 
-Metis used about 57% less time in this comparison. This is one user test, not a universal benchmark; results depend on the task, model, tools, and environment.
+## Documentation
 
-## What makes it reliable
+| Topic | Guide |
+| --- | --- |
+| Install, authenticate, and start | [Quickstart](docs/quickstart.md) |
+| Commands and interactive usage | [Using Metis](docs/usage.md) |
+| Providers and custom models | [Providers](docs/providers.md) · [Custom models](docs/models.md) |
+| Sessions and compaction | [Sessions](docs/sessions.md) · [Compaction](docs/compaction.md) |
+| Extensions, skills, and packages | [Extensions](docs/extensions.md) · [Skills](docs/skills.md) · [Packages](docs/packages.md) |
+| Programmatic integration | [SDK](docs/sdk.md) · [RPC](docs/rpc.md) · [JSON](docs/json.md) |
+| Video inspection | [Video tool](docs/video.md) |
+| Security and configuration | [Security](docs/security.md) · [Settings](docs/settings.md) |
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/images/metis-capabilities.dark.png" />
-    <img src="docs/images/metis-capabilities.png" width="100%" alt="Metis workflow, memory, search, and verification features" />
-  </picture>
-</p>
-
-### Deterministic workflow runtime
-
-Metis freezes a `StepSnapshot` before every model sample: model, reasoning level, Build/Plan mode, instruction stack, messages, visible tools, dispatcher, and context window. A tool call always executes against the snapshot that exposed it; a later step is the first point where a model, tool, extension, instruction, or mode change can take effect.
-
-The local dispatcher runs explicitly safe read tools in parallel and serializes write or mixed tools. Steering is consumed only after current tool results persist; follow-ups wait until the turn is otherwise complete. This preserves assistant/tool-result pairing through retry, compaction, abort, and resume.
-
-### Build and Plan
-
-New CLI, TUI, and Desktop conversations start in Plan. Restored, switched, and forked sessions retain their saved mode; explicit Build selection wins. SDK callers keep its compatible default unless they pass `collaborationMode`. In Build, non-trivial work initializes `update_plan` before mutation, keeps one active step, and updates the checklist through verification. Build also emits concise ordinary progress text in the user's language around meaningful tool batches.
-
-Plan is a read-only collaboration mode, not an OS sandbox. It hides and rejects write, mixed, shell, edit, and unclassified tools—including `update_plan`. It first grounds itself in repository evidence, uses `ask_user` only for material unresolved decisions, then returns a decision-complete `<proposed_plan>`. The latest proposal is a branch artifact: `read_plan` retrieves it after reload or context compaction. Switching back to Build restores the saved Build tool set. In Desktop, the latest proposal appears as a compact, expandable preview; **Process** switches to Build and immediately starts implementation and verification.
-
-Use `/mode build` or `/mode plan` in CLI. Desktop exposes the same idle-only choice next to the model selector. Desktop replaces its composer with one `ask_user` question at a time, then restores the editor after submit or cancel. The TUI renders proposals without protocol tags, limits the preview to 12 source lines, and replaces the idle composer with terminal-native **Process** and **Submit changes** actions. Process first reads the durable proposal and current execution progress, then creates the Build checklist before any other tool. CLI, Desktop, JSON, RPC, Server, and SDK share the same mode, context-window, plan, and instruction-source state. Hosts with an interactive handler can answer `ask_user`; print/JSON and unattended SDK runs receive a recoverable unsupported result instead of hanging.
-
-### Execution plans
-
-Build persists a task-scoped execution checklist with one active step at most. Desktop and TUI show one live “Execution plan” surface above the composer and update it in place, so progress remains visible while tools run, after abort, after compaction, and after session reload. During Process, the surface first shows proposal-reading and checklist-creation states; runtime blocks every other tool until `read_plan` and then `update_plan` succeed. The surface intentionally shows only execution status and checklist items; the complete approved proposal remains available through its conversational preview and `read_plan`. Raw `update_plan` tool cards stay hidden to avoid duplicate UI. Completed state clears when a later independent Build prompt starts, while interrupted work remains resumable. `read_plan` returns both the latest proposal and current execution checklist.
-
-### Memory
-
-Metis automatically checkpoints active task state after prompts, complete steps, compaction, errors, aborts, and completion. It never requires model bookkeeping calls or adds a foreground model round trip.
-
-The durable memory coordinator stores jobs, records, provenance, and a search index in `~/.metis/memories/state.sqlite`, with inspectable `MEMORY.md`, project views, and a summary index. It separates global preferences, project knowledge, and checkout-only facts. Metis exposes `search_memory` in Plan and Build so the model can search on demand, refine queries, and search again without a call-count limit; memory is no longer queried and injected automatically on every prompt. Results remain advisory evidence and cannot override current user, developer, or AGENTS instructions.
-
-Background extraction can use only `search_memory`, with no Metis-specific output-token cap or search-round cap. Reasoning-capable models run extraction at `low`; models without reasoning support receive no reasoning parameter. Provider and model limits, aborts, timeouts, per-search result limits, and the six-candidate checkpoint limit still apply.
-
-Use `/memory status|on|off|run|search|forget|reset`. `reset` requires explicit confirmation. `/memory status` and Desktop show why record count is zero, pending work, eligibility time, latest run counts, and fallback state. Proposal artifacts and long-term Memory are separate: no draft is automatically promoted to memory. Legacy Dream extensions, brain maps, and `.temp` memory logs are removed.
-
-### Search before action
-
-Metis investigates before making changes. It searches the repository first and uses web research when needed to check authoritative documentation, known solutions, release notes, or security information.
-
-### Logs and verification
-
-Metis records meaningful errors and completion summaries automatically. Before it says a task is finished, it compares the result with the user's original prompt and checks every requirement, constraint, and later clarification. It also runs relevant builds, tests, and functional checks when available.
-
-Together, these behaviors help the same coding model work with better context, fewer assumptions, and a stronger completion loop.
-
-## How it works
-
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/images/metis-workflow.dark.png" />
-    <img src="docs/images/metis-workflow.png" width="100%" alt="Metis workflow: Understand, Build, Verify" />
-  </picture>
-</p>
-
-1. **Freeze context** — assemble trusted base/developer instructions, untrusted runtime context, and the real user request; the model retrieves durable memory explicitly when useful.
-2. **Investigate or build** — Plan reads and proposes; Build changes only what evidence supports.
-3. **Persist and recover** — retain message/tool pairs, workflow checkpoints, structured plan state, and compaction summaries.
-4. **Verify and deliver** — run risk-proportionate checks, report evidence, and name remaining risk.
+See the [documentation index](docs/index.md) for every guide.
 
 <details>
 <summary><strong>Developer information</strong></summary>
 
-### Interfaces
+```bash
+npm run build                 # Compile TypeScript and copy runtime assets
+npm test                      # Run the Vitest suite
+npm run clean                 # Remove compiled output
+npm run build:binary          # Build the standalone binary
+```
 
-Metis supports an interactive terminal, print and JSON output, RPC integration, and an SDK for Node.js applications.
-
-The package exports the SDK from `@wholiver_hu/metis` and the RPC entry point from `@wholiver_hu/metis/rpc-entry`.
-
-### Commands
-
-| Command | Purpose |
-| --- | --- |
-| `npm run build` | Compile TypeScript and copy runtime assets. |
-| `npm test` | Run the Vitest test suite. |
-| `npm run clean` | Remove compiled output. |
-| `npm run build:binary` | Build the standalone binary. |
+The package exports the Node.js SDK from `@wholiver_hu/metis` and the RPC entry point from `@wholiver_hu/metis/rpc-entry`.
 
 </details>
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for core development, Extension integration, Package distribution, testing, and AI-assisted contribution guidance.
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for development, Extension and Package integration, testing, and AI-assisted contribution guidance.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,79 +17,83 @@
 </p>
 
 <p align="center">
-  <strong>通过更完整的上下文、可复用经验和结果验证，让编程模型写得更好、完成得更快。</strong>
+  <strong>贯穿终端与桌面的编程 Agent：搜索、记忆、执行、验证。</strong>
 </p>
 
 <p align="center">
   <a href="#快速开始">快速开始</a> ·
-  <a href="#为什么选择-metis">为什么选择 Metis</a> ·
-  <a href="#提升编程表现">编程表现</a> ·
-  <a href="#它为什么更可靠">可靠性</a>
+  <a href="#主要能力">主要能力</a> ·
+  <a href="#工作方式">工作方式</a> ·
+  <a href="#文档">文档</a>
 </p>
 
 ---
 
 ## 快速开始
 
-选择一种界面即可。两种方式共用同一套 Metis 配置、模型和会话。
+### CLI
 
-| 界面 | 适合场景 | 运行要求 |
-| --- | --- | --- |
-| **桌面应用** | 图形化工作区，内置 CLI 与 Server | Apple 芯片（`arm64`）Mac 或 Windows（`x64`） |
-| **CLI** | 终端、脚本、Print/JSON、RPC 与 SDK 集成 | Node.js `>=22.19.0` 和 `npm` |
-
-### macOS 桌面应用
-
-1. [下载最新版 Apple 芯片 `.dmg`](https://github.com/Wholiver/metis/releases/latest)（`Metis-*-macos-arm64.dmg`）。
-2. 打开安装包，将 **Metis.app** 拖入 **应用程序 (Applications)** 文件夹。
-3. 启动 **Metis**。Node.js 已包含在应用中。
-
-### Windows 桌面应用
-
-Windows 版同样内置完整的 Metis CLI 与 Server 运行环境。可选择安装版 EXE，也可选择免安装 ZIP。
-
-> **当前版本：** 支持 Windows `x64`，无需另行安装 Node.js。
-
-1. 打开[最新 GitHub Release](https://github.com/Wholiver/metis/releases/latest)。
-2. 下载并运行 `Metis-*-win-x64-setup.exe`；或下载 `Metis-*-win-x64.zip`，解压后进入 **Metis** 文件夹，双击 **Metis.exe**。
-3. 使用附带的 `.sha256` 文件校验下载内容。若 Windows SmartScreen 提示“未知发布者”，仅在文件来自官方 Release 页面时继续运行。
-
-### CLI 与命令行
-
-安装 Metis，然后启动交互式会话：
+需要 Node.js `>=22.19.0` 与 npm。
 
 ```bash
 npm install -g --ignore-scripts @wholiver_hu/metis@latest
 metis
 ```
 
-运行 `metis --help` 查看全部命令行选项。
+支持的订阅 Provider 可通过 `/login` 登录，也可配置 API Key。运行 `metis --help` 查看全部命令行选项；完整首次使用流程见[快速入门](docs/quickstart.md)。
 
-## 为什么选择 Metis
+<details>
+<summary><strong>桌面版安装（macOS 与 Windows）</strong></summary>
 
-Metis 是面向编程模型的 Agent 工作层。它不替换模型，也不修改模型权重，而是通过更好的搜索、记忆、执行和自检方式，提升模型的实际编程表现。
+桌面版已内置 Metis CLI 与 Server 运行环境，无需另行安装 Node.js。
 
-这意味着更深入地理解代码仓库、更少无依据的假设和需求遗漏、更可靠的任务闭环，以及更少重复上下文所消耗的时间。
+| 平台 | 架构 | 安装方式 |
+| --- | --- | --- |
+| macOS | Apple 芯片（`arm64`） | 下载 `Metis-*-macos-arm64.dmg`，再将 **Metis.app** 拖入**应用程序**。 |
+| Windows | `x64` | 运行 `Metis-*-win-x64-setup.exe`；或解压 `Metis-*-win-x64.zip` 后启动 **Metis.exe**。 |
 
-### 提升编程表现
+安装包及对应 `.sha256` 校验文件见[最新 GitHub Release](https://github.com/Wholiver/metis/releases/latest)。若 Windows SmartScreen 提示“未知发布者”，仅在文件来自官方 Release 页面且校验值一致时继续。
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/images/metis-coding-performance.zh-CN.dark.png" />
-    <img src="docs/images/metis-coding-performance.zh-CN.png" width="100%" alt="Metis 如何帮助同一个编程模型获得更好的编程结果" />
-  </picture>
-</p>
+</details>
 
-对于同一个底层模型，Metis 会强化模型周围的工作系统：
+## 主要能力
 
-- **相关上下文** — 修改前搜索代码仓库与权威资料。
-- **可复用经验** — 将有价值的决策、Lessons 和技术知识带入后续任务。
-- **基于证据的实现** — 遵循现有代码、约束和项目约定，而不是凭空猜测。
-- **经过验证的完成** — 构建、测试、检查输出，并对照用户原始要求确认结果。
+- **Plan 与 Build 工作流** — 在只读 Plan 模式中安全调查，再由 Build 模式按已确认方案执行，并持久保存检查清单。
+- **持久记忆与恢复** — 检索可复用的项目知识；中断、上下文压缩或会话重载后继续工作。
+- **灵活的模型与认证** — 使用内置订阅登录、API Key Provider，或带模型发现能力的自定义 OpenAI 兼容 Provider。
+- **桌面工作区** — 通过选择器、剪贴板或拖放添加图片、视频、文本及其他文件，并以图形界面管理 Provider 和会话。
+- **视频证据** — 通过元数据、时间戳故事板、有序运动样本、高清帧、字幕与本地转录检查视频。
+- **可扩展核心** — 加载 TypeScript Extensions、Agent Skills、Prompt Templates、Themes 与 Metis Packages；通过 Print、JSON、RPC、Server 或 Node.js SDK 集成。
+- **经过验证的执行** — 协调 Subagents、保持工具结果顺序、运行相关检查，并逐项对照原始要求交付。
 
-这些机制无需重新训练或替换模型，就能提升实际编码结果。最终效果仍取决于模型、任务、工具和运行环境。
+## 工作方式
 
-### 更快完成
+1. **建立依据** — 加载可信指令与相关上下文，按需搜索代码、记忆或权威资料。
+2. **规划或执行** — Plan 只读调查并生成持久方案；Build 只进行证据支持的修改。
+3. **保存状态** — 保留会话、消息/工具配对、工作流检查点、计划与压缩后的上下文。
+4. **验证结果** — 按风险运行检查，报告已完成要求、证据与剩余风险。
+
+<details>
+<summary><strong>技术设计</strong></summary>
+
+### 确定性工作流运行时
+
+每次模型采样前，Metis 都会冻结 `StepSnapshot`。模型、思考等级、协作模式、指令、消息、可见工具、Dispatcher 与上下文窗口在当前 Step 内保持一致。安全只读工具可并发运行；写入及混合工具串行运行。Steering 和 Follow-up 仅在当前工具结果持久化后生效。
+
+### 计划与交互输入
+
+新的交互式会话和 Desktop 会话默认进入 Plan。空闲时可用 `/mode plan` 与 `/mode build` 切换工作流。已确认方案通过 `read_plan` 跨重载和压缩保存；Build 清单在 TUI 与 Desktop 中原位更新。交互式 Host 可回答 `ask_user`；无人值守的 Print/JSON 与 SDK 运行会返回可恢复的 unsupported 结果，不会挂起。
+
+### 记忆
+
+Metis 会在 Prompt、完整 Step、上下文压缩、错误、中止及完成后自动保存活跃工作。持久记录和检索索引位于 `~/.metis/memories/state.sqlite`，并提供可检查的全局与项目 `MEMORY.md` 视图。Plan 与 Build 均可按需调用 `search_memory`；搜索结果只作为建议性证据，不能覆盖当前指令。
+
+使用 `/memory status|on|off|run|search|forget|reset`。方案 Artifact 与长期记忆彼此独立，未执行草案不会自动进入长期记忆。
+
+</details>
+
+<details>
+<summary><strong>性能样例</strong></summary>
 
 <p align="center">
   <picture>
@@ -98,98 +102,42 @@ Metis 是面向编程模型的 Agent 工作层。它不替换模型，也不修�
   </picture>
 </p>
 
-在一次使用相同任务的用户实测中：
+在一次相同任务的用户实测中，Metis 用时 1 分 30 秒，OpenCode 用时 3 分 30 秒，未观察到准确率差异。这只是单次对比，并非通用基准；实际结果取决于任务、模型、工具与运行环境。
 
-- **Metis 用时 1 分 30 秒。**
-- **OpenCode 用时 3 分 30 秒。**
-- 该次测试中没有观察到准确率差异。
+</details>
 
-在这次对比中，Metis 使用的时间减少了约 57%。这只是一次用户测试，并非通用基准；实际结果会受到任务、模型、工具和运行环境影响。
+## 文档
 
-## 它为什么更可靠
+| 主题 | 指南 |
+| --- | --- |
+| 安装、认证与首次运行 | [快速入门](docs/quickstart.md) |
+| 命令与交互式使用 | [使用 Metis](docs/usage.md) |
+| Provider 与自定义模型 | [Providers](docs/providers.md) · [Custom models](docs/models.md) |
+| 会话与上下文压缩 | [Sessions](docs/sessions.md) · [Compaction](docs/compaction.md) |
+| Extensions、Skills 与 Packages | [Extensions](docs/extensions.md) · [Skills](docs/skills.md) · [Packages](docs/packages.md) |
+| 程序化集成 | [SDK](docs/sdk.md) · [RPC](docs/rpc.md) · [JSON](docs/json.md) |
+| 视频检查 | [Video tool](docs/video.md) |
+| 安全与配置 | [Security](docs/security.md) · [Settings](docs/settings.md) |
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/images/metis-capabilities.zh-CN.dark.png" />
-    <img src="docs/images/metis-capabilities.zh-CN.png" width="100%" alt="Metis 的工作流、记忆、搜索和验证能力" />
-  </picture>
-</p>
-
-### 确定性工作流运行时
-
-每次模型采样前，Metis 都会冻结 `StepSnapshot`：模型、思考等级、Build/Plan 模式、指令栈、消息、可见工具、dispatcher 与上下文窗口。工具调用始终绑定到声明它的 snapshot；模型、工具、扩展、指令或模式变化只会在下一 step 生效。
-
-本地 dispatcher 会并发运行明确安全的只读工具，并串行运行 write/mixed 工具。Steering 只会在当前工具结果持久化后消费；follow-up 必须等待本轮其它工作结束。这样可在重试、压缩、中止和恢复时保持 assistant/tool-result 配对完整。
-
-### Build 与 Plan
-
-CLI、TUI 和 Desktop 的新会话默认进入 Plan；恢复、切换和 fork 的旧会话保留已保存模式，显式选择 Build 优先。SDK 为兼容性保留现有默认值，调用方可传入 `collaborationMode`。Build 拥有已配置工具和用户正常权限；非简单任务会在修改前初始化 `update_plan`，保持一个活跃步骤，并持续更新到验证完成。Build 也会在关键工具批次前后使用用户语言输出简短普通进度文字。
-
-Plan 是只读协作模式，不是 OS 沙箱。它会隐藏并硬拒绝 write、mixed、shell、edit、未分类工具以及 `update_plan`；先调查可发现事实，通过 `ask_user` 询问无法从仓库推导的关键偏好，最后输出决策完整的 `<proposed_plan>`。最新版 proposal 是分支级持久 artifact，重载或上下文压缩后模型仍可用 `read_plan` 读取全文。切回 Build 会恢复保存的 Build 工具集。Desktop 会把最新 proposal 显示为紧凑、可展开的预览；点击 **Process** 会先读取最新版，再切换到 Build 实施和验证。
-
-CLI 使用 `/mode build` 或 `/mode plan`；Desktop 在模型选择器旁提供同一套仅空闲时可切换的选项。Desktop 收到 `ask_user` 后会用单个问题替换输入框，逐题确认，提交或取消后恢复编辑器。TUI 会隐藏 proposal 协议标签，预览最多显示 12 个源文本行，并在空闲 composer 中提供终端原生的 **Process** 与 **提交更改**。Process 会先读取持久 proposal 与当前执行进度，再在使用其他工具前创建 Build 清单。CLI、Desktop、JSON、RPC、Server 与 SDK 共享模式、context window、计划和指令来源状态。TUI、Desktop 或配置了 handler 的 SDK 可回答 `ask_user`；print/JSON 与无人值守 SDK 会立即返回可恢复的 unsupported 结果，不会挂起。
-
-### 执行计划
-
-Build 会保存绑定当前任务的结构化执行 checklist，最多一个 `in_progress`。Desktop 与 TUI 都会在 composer 上方持续显示一张“执行计划”界面并原位更新，因此工具运行、中止、上下文压缩和会话恢复后仍可查看进度。Process 开始时先显示“读取方案”和“建立清单”状态；Runtime 会在 `read_plan`、随后 `update_plan` 成功前阻止任何其他工具。该界面只显示执行状态和清单项；完整已确认 proposal 仍可通过对话预览和 `read_plan` 读取。原始 `update_plan` 工具卡会隐藏，避免重复显示。已完成清单会在后续独立 Build Prompt 开始时清除，中止任务仍可继续。`read_plan` 同时返回最新版 proposal 和当前执行清单。
-
-### 记忆
-
-Metis 会在 prompt、完整 step、压缩、错误、中止和完成后自动写入活跃任务 checkpoint；不要求模型调用记忆工具，也不增加前台模型轮次。
-
-持久记忆协调器将任务、记录、来源和检索索引保存在 `~/.metis/memories/state.sqlite`，并生成可检查的 `MEMORY.md`、项目视图和摘要索引。全局偏好、项目知识和 checkout 路径事实彼此隔离。Plan 与 Build 都向模型提供 `search_memory`：模型按需主动搜索、改写查询并可不限次数继续搜索；Runtime 不再对每个 Prompt 自动检索和注入。搜索结果只是建议性证据，不能覆盖当前用户要求或 developer/AGENTS 指令。
-
-后台提取只开放 `search_memory`，Metis 不再额外设置输出 Token 上限或搜索轮数上限。支持 reasoning 的模型使用 `low`，不支持的模型完全省略 reasoning 参数。Provider/模型自身限制、中止、超时、单次搜索结果量和每 checkpoint 最多 6 条候选仍然生效。
-
-使用 `/memory status|on|off|run|search|forget|reset`；`reset` 必须明确确认。`/memory status` 和 Desktop 会说明零记录原因、pending/eligible 时间、最近处理与新增数量、模型失败和 fallback 状态。proposal artifact 与长期 Memory 相互独立，未执行草案不会自动进入长期记忆。旧 Dream 扩展、brain map 与 `.temp` 记忆日志已移除。
-
-### 先搜索，再行动
-
-Metis 会先调查，再修改。它先搜索代码仓库，并在需要时通过 Web 搜索核对权威文档、已知解决方案、版本说明或安全信息。
-
-### 日志与验证
-
-Metis 会自动记录有意义的错误和任务完成摘要。在宣布完成之前，它会把结果与用户最初的 Prompt 对比，逐项检查要求、限制条件和后续补充；如果项目提供构建、测试或功能检查，也会运行相关验证。
-
-这些机制让同一个编程模型获得更完整的上下文、更少的假设，以及更可靠的任务闭环，从而提升实际编码表现。
-
-## 工作方式
-
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/images/metis-workflow.zh-CN.dark.png" />
-    <img src="docs/images/metis-workflow.zh-CN.png" width="100%" alt="Metis 工作流：理解、执行、验证" />
-  </picture>
-</p>
-
-1. **冻结上下文** — 组合可信 base/developer 指令、不可信运行时 context、相关建议性记忆和真实用户要求。
-2. **调查或构建** — Plan 只读调查并提出方案；Build 只基于证据修改。
-3. **持久化与恢复** — 保存消息/工具配对、workflow checkpoint、结构化计划和压缩摘要。
-4. **验证与交付** — 按风险运行检查、报告证据，并说明剩余风险。
+全部指南见[文档索引](docs/index.md)。
 
 <details>
 <summary><strong>开发者信息</strong></summary>
 
-### 接口
+```bash
+npm run build                 # 编译 TypeScript 并复制运行时资源
+npm test                      # 运行 Vitest 测试套件
+npm run clean                 # 删除编译输出
+npm run build:binary          # 构建独立二进制文件
+```
 
-Metis 支持交互式终端、Print 和 JSON 输出、RPC 集成，以及面向 Node.js 应用的 SDK。
-
-软件包从 `@wholiver_hu/metis` 导出 SDK，并从 `@wholiver_hu/metis/rpc-entry` 导出 RPC 入口。
-
-### 常用命令
-
-| 命令 | 用途 |
-| --- | --- |
-| `npm run build` | 编译 TypeScript 并复制运行时资源。 |
-| `npm test` | 运行 Vitest 测试。 |
-| `npm run clean` | 删除编译输出。 |
-| `npm run build:binary` | 构建独立二进制文件。 |
+软件包从 `@wholiver_hu/metis` 导出 Node.js SDK，并从 `@wholiver_hu/metis/rpc-entry` 导出 RPC 入口。
 
 </details>
 
 ## 参与贡献
 
-欢迎参与 Metis 开发。核心功能开发、Extension 接入、Package 分发、测试与 AI 辅助开发说明见 [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md)。
+欢迎参与 Metis 开发。开发流程、Extension 与 Package 接入、测试及 AI 辅助贡献说明见 [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md)。
 
 ## 许可证
 


### PR DESCRIPTION
## What changed

- refreshed English and Simplified Chinese README content for the current Metis feature set
- documented Plan/Build workflows, durable memory, provider authentication, Desktop attachments, video evidence, extensibility, and integration modes
- moved Desktop installation, technical design, performance example, and developer commands into collapsible sections
- reduced each README from 196 lines to 144 lines

## Why

README content had fallen behind current product behavior and exposed too much implementation detail in the default view. This update makes installation and core capabilities easier to scan while preserving deeper material on demand.

## Validation

- `git diff --check`
- rendered both files through GitHub Markdown API
- verified heading, table, `<details>`, and `<summary>` output
- verified all local README links and image paths exist

Documentation-only change; no runtime tests were needed.