### PR TITLE
🛡️ Sentinel: [HIGH] Fix SQL injection bypass in read-only queries

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-21 - [Prevent SQLite comment bypass in read-only SQL queries]
+**Vulnerability:** The regex checking for mutating SQL keywords (INSERT, UPDATE, DELETE, etc.) in `src/core/memory-coordinator.ts` only checked for whitespace after a semicolon before the keyword (`/;\s*(?:INSERT...)/i`). This allowed an attacker to bypass the check by injecting SQL comments between the semicolon and the mutating keyword (e.g., `; /* bypass */ UPDATE...` or `; -- bypass\n UPDATE...`).
+**Learning:** Naive regular expressions checking for specific keywords in SQL are often vulnerable to comment injection and other forms of obfuscation.
+**Prevention:** Use a more robust regular expression that explicitly accounts for and matches SQL single-line and multi-line comments between semicolons and mutating keywords, or ideally, use a proper SQL parser to validate read-only intent.

--- a/src/core/memory-coordinator.ts
+++ b/src/core/memory-coordinator.ts
@@ -672,7 +672,7 @@ export class MemoryCoordinator {
 		if (!firstWord || !["SELECT", "WITH", "PRAGMA", "EXPLAIN"].includes(firstWord)) {
 			throw new Error(`Only read-only queries (SELECT, WITH, PRAGMA, EXPLAIN) are permitted. Received: ${firstWord || "unknown"}`);
 		}
-		if (/;\s*(?:INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|REPLACE|VACUUM|ATTACH|DETACH)\b/i.test(normalized)) {
+		if (/;\s*(?:(?:--[^\n]*\n|\/\*[\s\S]*?\*\/)\s*)*(?:INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|REPLACE|VACUUM|ATTACH|DETACH)\b/i.test(normalized)) {
 			throw new Error("Multiple statements with mutating operations are strictly forbidden.");
 		}
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The regex used to prevent mutating SQL queries (INSERT, UPDATE, DELETE, etc.) in `src/core/memory-coordinator.ts` only checked for whitespace after a semicolon before the keyword (`/;\s*(?:INSERT...)/i`). This allowed an attacker to bypass the check by injecting SQL comments between the semicolon and the mutating keyword (e.g., `; /* bypass */ UPDATE...` or `; -- bypass\n UPDATE...`).
🎯 Impact: An attacker could bypass the read-only query protections and execute arbitrary mutating queries against the memory database.
🔧 Fix: Updated the regular expression to properly account for single-line (`--`) and multi-line (`/* ... */`) SQL comments between semicolons and mutating keywords.
✅ Verification: Tested the regex with various bypass attempts and ensured `npm run test` passes without introducing regressions.

---
*PR created automatically by Jules for task [3863764686344905557](https://jules.google.com/task/3863764686344905557) started by @Wholiver*