### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix safeEqual timing attack

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-10-24 - [Fix safeEqual timing attack]
+**Vulnerability:** The `safeEqual` function used for password comparison contained a timing vulnerability. It returned `false` immediately if the lengths of the `actual` and `expected` strings didn't match. This allowed an attacker to guess the length of the expected string by measuring response times.
+**Learning:** Even when using `crypto.timingSafeEqual`, the inputs to the function must be exactly the same length. Returning early based on length defeats the purpose of the constant-time comparison for secrets.
+**Prevention:** Before comparing arbitrary-length strings securely, hash both strings (e.g. using SHA-256) and then compare the hashes using `timingSafeEqual`. This guarantees the buffers are always the same length and completely mitigates length-based timing attacks.

--- a/src/modes/server/server-mode.ts
+++ b/src/modes/server/server-mode.ts
@@ -1145,9 +1145,9 @@ function isAuthorized(request: IncomingMessage, username: string, password: stri
 }
 
 function safeEqual(actual: string, expected: string): boolean {
-	const actualBuffer = Buffer.from(actual);
-	const expectedBuffer = Buffer.from(expected);
-	return actualBuffer.length === expectedBuffer.length && crypto.timingSafeEqual(actualBuffer, expectedBuffer);
+	const actualHash = crypto.createHash("sha256").update(actual).digest();
+	const expectedHash = crypto.createHash("sha256").update(expected).digest();
+	return crypto.timingSafeEqual(actualHash, expectedHash);
 }
 
 function isLoopbackHostname(hostname: string): boolean {


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix safeEqual timing attack

🚨 Severity: CRITICAL
💡 Vulnerability: The `safeEqual` function in `server-mode.ts` used to check password equivalence had a timing attack vulnerability. It returned early if the lengths of the two strings didn't match. This leaked the length of the valid password to a potential attacker by varying the response time.
🎯 Impact: An attacker could deduce the exact length of the server password, drastically narrowing down the brute force search space for guessing the password.
🔧 Fix: Modifies the `safeEqual` function to hash both `actual` and `expected` values with SHA-256 before comparing them using `crypto.timingSafeEqual`. This ensures the inputs passed to the comparison function are always 32 bytes long, providing a true constant-time comparison that eliminates length leakage.
✅ Verification: Covered by existing unit tests in `test/server-mode.test.ts`.

---
*PR created automatically by Jules for task [11040886295776999230](https://jules.google.com/task/11040886295776999230) started by @Wholiver*