### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix incomplete secret redaction regex

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [CRITICAL] Fix incomplete secret redaction regex
+**Vulnerability:** The `SECRET` regex used in `src/core/memory-coordinator.ts` for redacting secrets before storing them in memory failed to redact JSON formatted secrets (e.g., `"apiKey": "sk_abc123"`) due to quotation marks, and it also failed to redact the actual token for HTTP Authorization headers (e.g., `authorization: Bearer mytoken`) because it captured the prefix `Bearer` instead of the token.
+**Learning:** Hardcoded regular expressions for redaction are notoriously difficult to get right, especially when handling various formats like JSON strings and HTTP headers.
+**Prevention:** In the future, when working with redaction regex, test edge cases such as token prefixes (`Bearer `, `Token `), structural wrapping (JSON quotes), and query parameters (`?api_key=secret&test=1`).

--- a/src/core/memory-coordinator.ts
+++ b/src/core/memory-coordinator.ts
@@ -183,7 +183,7 @@ export interface MemoryExtractionResult {
 
 type Listener = (event: { type: "memory_state_changed"; state: MemoryState } | { type: "memory_records_changed" }) => void;
 
-const SECRET = /(?:\b(?:sk|rk|pk)_[A-Za-z0-9_-]{16,}\b|\b(?:api[_-]?key|authorization|password|token)\s*[:=]\s*[^\s,;]+)/gi;
+const SECRET = /(?:\b(?:sk|rk|pk)_[A-Za-z0-9_-]{16,}\b|["']?(?:api[_-]?key|authorization|password|token)["']?\s*[:=]\s*(?:(?:Bearer|Token)\s+)?["']?[^\s,;"']+["']?)/gi;
 const DAY = 86_400_000;
 
 function hash(value: string): string {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `SECRET` regex used for redacting secrets before they are stored in the memory logs failed to capture the actual token in `authorization: Bearer <token>` (it only captured the string "Bearer"). It also failed to handle JSON-quoted secrets correctly (e.g. `"apiKey": "sk_abc123"`).
🎯 Impact: This could result in actual API keys and tokens being leaked into memory logs in plain text, specifically when passed in structured data (JSON) or via standard HTTP Auth headers.
🔧 Fix: Updated the `SECRET` regex in `src/core/memory-coordinator.ts` to `/(?:\b(?:sk|rk|pk)_[A-Za-z0-9_-]{16,}\b|["']?(?:api[_-]?key|authorization|password|token)["']?\s*[:=]\s*(?:(?:Bearer|Token)\s+)?["']?[^\s,;"']+["']?)/gi`. This effectively strips quotes and handles `Bearer` or `Token` prefixes.
✅ Verification: Ran testing scripts to ensure proper regex matching of strings, verifying it correctly extracts the token value from the string rather than the prefix. Tested that `pnpm test test/memory-coordinator.test.ts` still passes.

---
*PR created automatically by Jules for task [9805204720321043866](https://jules.google.com/task/9805204720321043866) started by @Wholiver*